### PR TITLE
Rework expiry

### DIFF
--- a/config.default.json.example
+++ b/config.default.json.example
@@ -3,9 +3,7 @@
   "server_name" : "brubeck_debug",
   "dumpfile" : "./brubeck.dump",
   "capacity" : 15,
-  "expire" : 20,
   "http" : ":8080",
-
   "backends" : [
     {
       "type" : "carbon",

--- a/src/http.c
+++ b/src/http.c
@@ -59,7 +59,7 @@ static struct MHD_Response *expire_metric(struct brubeck_server *server,
       safe_lookup_metric(server, url + strlen("/expire/"));
 
   if (metric) {
-    metric->expire = BRUBECK_EXPIRE_DISABLED;
+    brubeck_metric_set_state(metric, BRUBECK_STATE_DISABLED);
     return MHD_create_response_from_data(0, "", 0, 0);
   }
   return NULL;
@@ -75,14 +75,15 @@ static struct MHD_Response *send_metric(struct brubeck_server *server,
       safe_lookup_metric(server, url + strlen("/metric/"));
 
   if (metric) {
-    json_t *mj = json_pack("{s:s, s:s, s:i, s:s}", "key", metric->key, "type",
-                           metric_types[metric->type],
+    json_t *mj =
+        json_pack("{s:s, s:s, s:i, s:s}", "key", metric->key, "type",
+                  metric_types[metric->type],
 #if METRIC_SHARD_SPECIFIER
-                           "shard", (int)metric->shard,
+                  "shard", (int)metric->shard,
 #else
-                           "shard", 0,
+                  "shard", 0,
 #endif
-                           "expire", expire_status[metric->expire]);
+                  "expire", expire_status[brubeck_metric_get_state(metric)]);
 
     char *jsonr = json_dumps(mj, JSON_INDENT(4) | JSON_PRESERVE_ORDER);
     json_decref(mj);

--- a/src/internal_sampler.c
+++ b/src/internal_sampler.c
@@ -57,7 +57,7 @@ void brubeck_internal__sample(struct brubeck_metric *metric,
    * Mark the metric as active so it doesn't get disabled
    * by the inactive metrics pruner
    */
-  metric->expire = BRUBECK_EXPIRE_ACTIVE;
+  brubeck_metric_set_state(metric, BRUBECK_STATE_ACTIVE);
 }
 
 void brubeck_internal__init(struct brubeck_server *server) {

--- a/src/metric.c
+++ b/src/metric.c
@@ -24,7 +24,7 @@ static inline struct brubeck_metric *new_metric(struct brubeck_server *server,
   metric->key[key_len] = '\0';
   metric->key_len = (uint16_t)key_len;
 
-  metric->expire = BRUBECK_EXPIRE_ACTIVE;
+  brubeck_metric_set_state(metric, BRUBECK_STATE_ACTIVE);
   metric->type = type;
   pthread_spin_init(&metric->lock, PTHREAD_PROCESS_PRIVATE);
 
@@ -239,6 +239,7 @@ void brubeck_metric_sample(struct brubeck_metric *metric, brubeck_sample_cb cb,
 
 void brubeck_metric_record(struct brubeck_metric *metric, value_t value,
                            value_t sample_freq, uint8_t modifiers) {
+  brubeck_metric_set_state(metric, BRUBECK_STATE_ACTIVE);
   _prototypes[metric->type].record(metric, value, sample_freq, modifiers);
 }
 
@@ -288,6 +289,5 @@ struct brubeck_metric *brubeck_metric_find(struct brubeck_server *server,
   brubeck_atomic_inc(&metric->flow);
 #endif
 
-  metric->expire = BRUBECK_EXPIRE_ACTIVE;
   return metric;
 }

--- a/src/tags.c
+++ b/src/tags.c
@@ -138,7 +138,7 @@ brubeck_get_tag_set_of_tag_str(struct brubeck_tags_t *tags, const char *tag_str,
        life of the hash table entry
     */
     char *tag_str_for_parse = strdup(tag_str);
-    const char *tag_str_for_key = strdup(tag_str);
+    char *tag_str_for_key = strdup(tag_str);
     tag_set = brubeck_parse_tags(tag_str_for_parse, tag_str_len);
     if (!brubeck_tags_insert(tags, tag_str_for_key, tag_str_len, tag_set)) {
       free(tag_set);

--- a/tests/main.c
+++ b/tests/main.c
@@ -16,6 +16,7 @@ void test_ftoa(void);
 void test_statsd_msg__parse_strings(void);
 void test_tag_parsing(void);
 void test_tag_storage(void);
+void test_tag_offset(void);
 
 int main(int argc, char *argv[]) {
   sput_start_testing();


### PR DESCRIPTION
The expiration mechanism in brubeck is inefficient, isn't thread-safe, and can result in unexpected operation if misconfigured.

Remove timed iterative expiry and instead mutate state when sampled into a backend.